### PR TITLE
General improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,15 @@ You can pass options when configuring the middleware to customize behaviour:
 ```csharp
 services.AddRazorPagesSitemap(options =>
 {
-    options.BaseLastModOnLastModifiedTimeOnDisk = true; //default == true. This will set the <lastmod /> element to be based on the last modified time on disk
-    options.IgnorePathsEndingInIndex = true; //default == true. This will avoid adding duplicate from matching `/mypath` and `/mypath/index`
-    options.IgnoreExpression = @"error\/\d{3}$"; //default is null. Allows you to opt out certain patch matches based on regular expressions. In this case we're skipping the pages matching /error/123
+    // This will set the <lastmod /> element to be based on the last modified time on disk
+    options.BaseLastModOnLastModifiedTimeOnDisk = true; // default is true
+
+    // This will avoid adding duplicate from matching `/mypath` and `/mypath/index`
+    options.IgnorePathsEndingInIndex = true; // default is true
+
+    // Allows you to opt out certain patch matches based on regular expressions. In this case
+    // we're skipping the pages matching /error/123
+    options.IgnoreExpression = @"error\/\d{3}$"; // default is null
 });
 ```
 
@@ -39,4 +45,3 @@ By default, the sitemap will be available at `/sitemap.xml`. You can customize t
 ```csharp
 app.UseRazorPagesSitemap("/myAlternatePath");
 ```
-

--- a/SodaPop.RazorPagesSitemap/RazorPagesSitemapMiddleware.cs
+++ b/SodaPop.RazorPagesSitemap/RazorPagesSitemapMiddleware.cs
@@ -79,8 +79,6 @@ namespace SodaPop.RazorPagesSitemap
                 var xmlAsString = await sr.ReadToEndAsync();
                 await context.Response.WriteAsync(xmlAsString);
             }
-
-            await next(context);
         }
     }
 }

--- a/SodaPop.RazorPagesSitemap/RazorPagesSitemapMiddleware.cs
+++ b/SodaPop.RazorPagesSitemap/RazorPagesSitemapMiddleware.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.Extensions.Options;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -32,7 +31,7 @@ namespace SodaPop.RazorPagesSitemap
             }
         }
 
-        public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+        public Task InvokeAsync(HttpContext context, RequestDelegate next)
         {
             var baseDomain = context.Request.Scheme + "://" + context.Request.Host + "/";
 
@@ -70,15 +69,9 @@ namespace SodaPop.RazorPagesSitemap
             context.Response.Headers.Add("Content-Type", "application/xml");
 
             var serializer = new XmlSerializer(typeof(Sitemap));
-            using (var ms = new MemoryStream())
-            using (var sr = new StreamReader(ms))
-            {
-                serializer.Serialize(ms, sitemap);
-                ms.Position = 0;
+            serializer.Serialize(context.Response.Body, sitemap);
 
-                var xmlAsString = await sr.ReadToEndAsync();
-                await context.Response.WriteAsync(xmlAsString);
-            }
+            return Task.CompletedTask;
         }
     }
 }

--- a/SodaPop.RazorPagesSitemap/RazorPagesSitemapMiddleware.cs
+++ b/SodaPop.RazorPagesSitemap/RazorPagesSitemapMiddleware.cs
@@ -35,11 +35,10 @@ namespace SodaPop.RazorPagesSitemap
         {
             var baseDomain = context.Request.Scheme + "://" + context.Request.Host + "/";
 
-            var sitemap = new Sitemap();
-
             var nodes = new List<SitemapNode>();
 
-            foreach (PageActionDescriptor page in _actionDescriptorCollectionProvider.ActionDescriptors.Items.Where(x => x is PageActionDescriptor))
+            var pages = _actionDescriptorCollectionProvider.ActionDescriptors.Items.Where(x => x is PageActionDescriptor);
+            foreach (PageActionDescriptor page in pages)
             {
                 if (_options.IgnorePathsEndingInIndex && page.ViewEnginePath.EndsWith("/index"))
                 {
@@ -64,9 +63,12 @@ namespace SodaPop.RazorPagesSitemap
                 nodes.Add(node);
             }
 
-            sitemap.Nodes = nodes;
+            var sitemap = new Sitemap()
+            {
+                Nodes = nodes
+            };
 
-            context.Response.Headers.Add("Content-Type", "application/xml");
+            context.Response.ContentType = "application/xml";
 
             var serializer = new XmlSerializer(typeof(Sitemap));
             serializer.Serialize(context.Response.Body, sitemap);

--- a/SodaPop.RazorPagesSitemap/RazorPagesSitemapMiddlewareExtensions.cs
+++ b/SodaPop.RazorPagesSitemap/RazorPagesSitemapMiddlewareExtensions.cs
@@ -14,12 +14,15 @@ namespace SodaPop.RazorPagesSitemap
 
         public static IServiceCollection AddRazorPagesSitemap(this IServiceCollection services)
         {
-            return services.AddRazorPagesSitemap(_ => new RazorPagesSitemapOptions());
+            return services.AddRazorPagesSitemap(setupAction: null);
         }
 
         public static IServiceCollection AddRazorPagesSitemap(this IServiceCollection services, Action<RazorPagesSitemapOptions> setupAction)
         {
-            services.Configure(setupAction);
+            if (setupAction != null)
+            {
+                services.Configure(setupAction);
+            }
             services.AddTransient<RazorPagesSitemapMiddleware>();
 
             return services;


### PR DESCRIPTION
You asked for it, here is a first pull request.

- Stop the pipeline after handling the request, to avoid subsequent middlewares from running as well (this generally causes exceptions)
- Adjust the configure action passing. Option objects are usually created once by the options manager and then all configured actions are called in a sequence to configure that one object. So one should avoid creating an explicit instance here.
- Stream the serialized XML directly to the body instead of creating a memory stream first.
- And some minor (style) adjustments.